### PR TITLE
Implement `inspectCustomString`

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ function inspectCustomString(value, depth, opts) {
   if (value.includes('\n')) {
     value = value.replaceAll('\n', '\n' + '  '.repeat(depth))
 
-    opts.breakAlways = true
+    opts = { ...opts, breakAlways: true }
   }
 
   return new InspectLeaf(value, null, depth, opts)

--- a/index.js
+++ b/index.js
@@ -232,7 +232,8 @@ class InspectSequence extends InspectNode {
     const split =
       this.values.length &&
       (offset + this.length > this.breakLength ||
-        indent * 2 + this.length > this.breakLength)
+        indent * 2 + this.length > this.breakLength ||
+        this.values.some((v) => v.breakAlways))
 
     let header = this.header
 
@@ -345,6 +346,16 @@ function inspectNull(depth, opts) {
   return new InspectLeaf('null', styles.null, depth, opts)
 }
 
+function inspectCustomString(value, depth, opts) {
+  if (value.includes('\n')) {
+    value = value.replaceAll('\n', '\n' + '  '.repeat(depth))
+
+    opts.breakAlways = true
+  }
+
+  return new InspectLeaf(value, null, depth, opts)
+}
+
 function inspectBoolean(value, depth, opts) {
   return new InspectLeaf(value.toString(), styles.boolean, depth, opts)
 }
@@ -442,7 +453,7 @@ function inspectObject(type, object, depth, opts) {
       return inspectValue(value, depth, opts)
     }
 
-    return value
+    return inspectCustomString(value, depth, opts)
   }
 
   if (type.isArray()) return inspectArray(object, ref, depth, opts)

--- a/test.js
+++ b/test.js
@@ -48,6 +48,12 @@ test('arrays', (t) => {
   `,
     'long array'
   )
+
+  t.is(
+    inspect(['foo\nbar', 'one\ntwo']),
+    "[ 'foo\\nbar', 'one\\ntwo' ]",
+    'multi-line string array'
+  )
 })
 
 test('dates', (t) => {
@@ -468,6 +474,16 @@ test('custom inspect method', (t) => {
   t.is(inspect(new Foo()), 'Foo { bar: false }')
 })
 
+test('custom inspect method with multi-line string result', (t) => {
+  class Foo {
+    [Symbol.for('bare.inspect')]() {
+      return 'Foo\nBar'
+    }
+  }
+
+  t.is(inspect(new Foo()), 'Foo\nBar')
+})
+
 test('custom inspect method with cycle', (t) => {
   class Foo {
     [Symbol.for('bare.inspect')]() {
@@ -513,6 +529,24 @@ test('custom inspect method with custom stylize', (t) => {
   }
 
   t.is(inspect(new Foo(), { stylize }), 'FOO')
+})
+
+test('array of custom inspect method with multi-line string result', (t) => {
+  class Foo {
+    [Symbol.for('bare.inspect')]() {
+      return 'One\ntwo'
+    }
+  }
+
+  t.is(
+    inspect([new Foo()]),
+    trim`
+[
+  One
+  two
+]
+`
+  )
 })
 
 test('custom inspect method, Node.js compatibility', (t) => {


### PR DESCRIPTION
Previously, "value" could be a plain string, hence lines like `value.toString({ indent: indent + 1, pad })` wasn't applying the formatting nuances.

The `value.replaceAll('\n', '\n' + '  '.repeat(depth))` part was inspired by https://github.com/nodejs/node/blob/4612c793cb9007a91cb3fd82afe518440473826e/lib/internal/util/inspect.js#L1151