### PR TITLE
Inspect symbol keys from objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,7 +487,9 @@ function inspectObject(type, object, depth, opts) {
 
   const values = []
 
-  for (const key of Object.getOwnPropertySymbols(object)) {
+  for (const key in object) {
+    if (key === 'constructor') continue
+
     values.push(
       new InspectPair(
         ': ',
@@ -499,9 +501,7 @@ function inspectObject(type, object, depth, opts) {
     )
   }
 
-  for (const key in object) {
-    if (key === 'constructor') continue
-
+  for (const key of Object.getOwnPropertySymbols(object)) {
     values.push(
       new InspectPair(
         ': ',

--- a/index.js
+++ b/index.js
@@ -406,6 +406,10 @@ function inspectSymbol(value, depth, opts) {
 const PLAIN_KEY = /^[a-zA-Z_][a-zA-Z_0-9]*$/
 
 function inspectKey(value, depth, opts) {
+  const type = getType(value)
+
+  if (type.isSymbol()) return inspectValue(value, depth, opts)
+
   if (PLAIN_KEY.test(value)) {
     return new InspectLeaf(value, null, depth, opts)
   } else {
@@ -482,6 +486,18 @@ function inspectObject(type, object, depth, opts) {
   ref.increment()
 
   const values = []
+
+  for (const key of Object.getOwnPropertySymbols(object)) {
+    values.push(
+      new InspectPair(
+        ': ',
+        inspectKey(key, depth + 1, opts),
+        inspectValue(object[key], depth + 1, opts),
+        depth + 1,
+        opts
+      )
+    )
+  }
 
   for (const key in object) {
     if (key === 'constructor') continue

--- a/test.js
+++ b/test.js
@@ -151,6 +151,8 @@ test('objects', (t) => {
   t.is(inspect({}), '{}', 'empty object')
 
   t.is(inspect({ hello: 'world' }), "{ hello: 'world' }")
+
+  t.is(inspect({ [Symbol('foo')]: 'bar' }), "{ Symbol(foo): 'bar' }")
 })
 
 test('errors', (t) => {

--- a/test.js
+++ b/test.js
@@ -152,7 +152,10 @@ test('objects', (t) => {
 
   t.is(inspect({ hello: 'world' }), "{ hello: 'world' }")
 
-  t.is(inspect({ [Symbol('foo')]: 'bar' }), "{ Symbol(foo): 'bar' }")
+  t.is(
+    inspect({ foo: 'bar', [Symbol('foo')]: 'bar', bar: 'foo' }),
+    "{ foo: 'bar', bar: 'foo', Symbol(foo): 'bar' }"
+  )
 })
 
 test('errors', (t) => {


### PR DESCRIPTION
Currently, symbol keys are ignored by the "for (const key in object) {}" loop.